### PR TITLE
found some typos

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -387,9 +387,11 @@ be any number of things like `public_html` for generic hosts.
 #### artifact_workspace
 This setting moves where the built artifact should be. This is particularly
 helpful when you want to pick and choose items from the build versus just
-sending the whole artifact to your host. The `~/project` directory is the
-that is committed to an "Artifact Build". By default, this value is also
-`~/project`, so that everything that was built during the "build" job is then
+sending the whole artifact to your host. The `~/project` directory is always
+committed to an "Artifact Build". Therefore, by changing this directory to
+something like `/tmp/project`, you can use rsync to move parts built by
+the previous build script into `~/project`. By default, this value of this setting
+is `~/project`, so that everything that was built during the "build" job is then
 pushed to the host.
 
 ### Other Configuration

--- a/README.MD
+++ b/README.MD
@@ -430,7 +430,7 @@ mandatory environment variables in this way as well.
    * Pantheon: dev, test, live
 
    Default: "prod" on Acquia. "live" on Pantheon
-* `SANITIZE_SCRIPT`: Script used to sanitize databases. Only used when
+* `SANATIZE_SCRIPT`: Script used to sanatize databases. Only used when
    `CANONICAL_ENV` is not dev. There is no default.
 * `SYNC_CONFIG`: The ability to turn configuration sync on or off. By default,
    Yes if Any directory in the ./config directory (inclusive) contains

--- a/README.MD
+++ b/README.MD
@@ -1,7 +1,7 @@
 # Circle CI Starter for Projects
 
 This Composer package provides the starts for what you need to test and deploy
-an hosted site on something like Acquia.
+a hosted site on something like Acquia.
 
 ## TOC
 
@@ -11,31 +11,31 @@ an hosted site on something like Acquia.
 * [Configure Environment](#configure-environment)
    + [Shared](#shared)
       - [Deploy Bot Setup](#deploy-bot-setup)
-         * [Create a Github Account for the Deploy Bot](#create-a-github-account-for-the-deploy-bot)
+         * [Create a GitHub Account for the Deploy Bot](#create-a-github-account-for-the-deploy-bot)
       - [Configure an SSH Key](#configure-an-ssh-key)
       - [Get a Github Token](#get-a-github-token)
       - [Configure Environment Variables](#configure-environment-variables)
    + [Pantheon](#pantheon)
       - [Create a Pantheon Account for your Deploy Bot](#create-a-pantheon-account-for-your-deploy-bot)
       - [Set up SSH Key](#set-up-ssh-key)
-      - [Get a Terminus Token (or Machine Token)](#get-a-terminus-token--or-machine-token-)
+      - [Get a Terminus Token (or Machine Token)](#get-a-terminus-token-or-machine-token)
       - [Configure More CircleCi Environment Variables](#configure-more-circleci-environment-variables)
    + [Acquia](#acquia)
-      - [Create a Acquia Account for your Deploy Bot](#create-a-acquia-account-for-your-deploy-bot)
+      - [Create an Acquia Account for your Deploy Bot](#create-an-acquia-account-for-your-deploy-bot)
       - [Set up SSH Key](#set-up-ssh-key-1)
       - [Configure More CircleCi Environment Variables](#configure-more-circleci-environment-variables-1)
 * [Configure CircleCI config.yml](#configure-circleci-configyml)
    + [Pipeline Parameter Defaults](#pipeline-parameter-defaults)
-      - [php-version:](#php-version-)
+      - [php-version](#php-version)
       - [tz](#tz)
       - [host-variant](#host-variant)
          * [pantheon](#pantheon)
          * [acquia](#acquia)
          * [general](#general)
       - [docroot](#docroot)
-      - [artifact_workspace](#artifact-workspace)
+      - [artifact_workspace](#artifact_workspace)
    + [Other Configuration](#other-configuration)
-      - [persisting_dirs](#persisting-dirs)
+      - [persisting_dirs](#persisting_dirs)
 * [Configurable Environment Variables](#configurable-environment-variables)
    + [Shared](#shared-1)
    + [Pantheon Specific](#pantheon-specific)
@@ -67,7 +67,7 @@ run out of the box:
 - the composer scripts lint and code-sniff. Example:
   ```
    "scripts": {
-      lint: [
+      "lint": [
          "./node_modules/.bin/eslint ./",
          "find web/modules/custom web/themes/custom \\( -iname  '*.php' -o -iname '*.inc' -o -iname '*.module' -o -iname '*.install'-o -iname '*.theme' \\) '!' -path '*/node_modules/*' -print0 | xargs -0 -n1 -P8 php -l"
       ],
@@ -88,10 +88,10 @@ run out of the box:
   Here's an example [.gitignore](https://github.com/pantheon-systems/example-drops-8-composer/blob/master/.gitignore).
 
 Set up of the Circle tasks assumes you are doing this with a bot user. Please
-ensure that the bot user you are using has account on both the github
-organization where your site lives as well as the hosting provider. You will
+ensure that the bot user you are using has account on both the GitHub
+organization where your site lives and the hosting provider. You will
 need:
- - the ability to log in as the bot user in github and on the hosting provider
+ - the ability to log in as the bot user in GitHub and on the hosting provider
  - an SSH Key (private and public)
  - an api or machine token for the hosting tooling such as terminus or acli
 
@@ -106,19 +106,19 @@ need:
     ```
 2. Make sure your composer.json and package.json meet the requirements of the
    default scripts.
-2. Push the changes to a public github branch.
-3. Log in to https://app.circleci.com/
-4. Navigate to the organization that your site's code lives under by clicking
+3. Push the changes to a public GitHub branch.
+4. Log in to https://app.circleci.com/
+5. Navigate to the organization that your site's code lives under by clicking
    the icon in the top left corner where your name is and selecting the correct
    one.
-5. Navigate to Projects
-6. Find the Repo name for your site
-7. Click the "Set Up Project" button next to it
-8. Choose Fastest
-9. Type in the branch you pushed your changes up to where the "git branch" icon
-   is in the dialog.
-10. Verify the wrench icon turns Green and lets you know it found a config.jon
-11. Click "Set Up Project"
+6. Navigate to Projects
+7. Find the Repo name for your site
+8. Click the "Set Up Project" button next to it
+9. Choose Fastest
+10. Type in the branch you pushed your changes up to where the "git branch" icon
+    is in the dialog.
+11. Verify the wrench icon turns Green and lets you know it found a config.json
+12. Click "Set Up Project"
 
 The first pass will always fail. Move on to configuration.
 ## Configure Environment
@@ -130,16 +130,16 @@ to.
 ### Shared
 
 #### Deploy Bot Setup
-A Deploy bot user will be needed. This tooling assumes Bender (the Four Kitchens
+A Deploy Bot user will be needed. This tooling assumes Bender (the Four Kitchens
 deploy bot) as the default, but does not provide any credentials you need to set
 the tooling up. Ask a Web Chef about Bender, have the organization you are
 working with create a new bot, or create the new bot for them using the steps
 below. You will need to log in as this bot to do some of the configuration.
 
-##### Create a Github Account for the Deploy Bot
-1. Open a new browser instance or log out of your current github instance.
+##### Create a GitHub Account for the Deploy Bot
+1. Open a new browser instance or log out of your current GitHub instance.
 2. Go to https://github.com/join.
-3. Type a user name, your email address, and a password. NOTE: Make sure the
+3. Type a username, your email address, and a password. NOTE: Make sure the
    email address you enter goes to a real email account. If you use gmail, it is
    possible to have multiple "addresses" go to the same account using the `+` in
    your email. See how to [create task-specific email addresses](https://support.google.com/a/users/answer/9308648?hl=en)
@@ -161,32 +161,32 @@ and securely provide the ssh key pair to the client.
    one.
 3. Navigate to Projects
 4. Find the Repo name for your site and click it.
-5. Validate you see you see failed workflows.
+5. Validate you see failed workflows.
 6. Click on "Project Settings"
 7. Click on "SSH Keys"
 8. Navigate to "Additional SSH Keys"
 9. Click "Add SSH Key"
 10. Copy the contents of the private SSH Key you were provided (or generated)
     for the bot user into the Private Key field in the dialog that appears.
-11. Verify that you have no extraneous spaces or newlines
+11. Verify that you have no extraneous spaces or newlines.
 12. Click "Add SSH Key" to close the dialog and accept the changes.
-13. Note the Finger Print for future use. **Note:** you can check to make sure
+13. Note the fingerprint for future use. **Note:** you can check to make sure
     the file was copied correctly by validating that the fingerprint in circleci
     is the same as what is displayed by the command
     `ssh-keygen -l -E md5 -f id_rsa` where idrsa is the filename of your key.
 
 #### Get a Github Token
-You must have a github token so the deploy bot can post comments back to commits
+You must have a GitHub token so the Deploy Bot can post comments back to commits
 or pull requests. This allows it to provide links and information about the
 environments it created.
 
 If you skipped here, make sure you follow steps 1-6 of "Configure an SSH Key" to
 get to Circle's Project Settings"
 
-1. In a new browser instance, log in to Github as the Deploy bot.
+1. In a new browser instance, log in to GitHub as the Deploy Bot.
 2. Follow the instructions for [creating a personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token#creating-a-token)
 3. Choose just repo:status, repo_deployment and public_repo for scopes
-4. Save the access token securely so you will have access to it. It will only
+4. Save the access token securely, so you will have access to it. It will only
    be displayed once.
 
 #### Configure Environment Variables
@@ -195,7 +195,7 @@ Here you will configure the common environment variables. Hosting specific
 variables and steps will be provided farther down. The variables to configure
 are as follows.
 
-* `GITHUB_TOKEN` A github access token so the bot user can comment back on the
+* `GITHUB_TOKEN` A GitHub access token so the bot user can comment back on the
   commit.
 * `GIT_EMAIL` An arbitrary email that will be used as the committer when
   building the artifact.
@@ -213,7 +213,7 @@ get to Circle's Project Settings"
 6. Click "Add Environment Variable" to accept the changes.
 7. Click "Add Environment Variable"
 8. Type "GIT_EMAIL" in the name
-9. Type the email address associated with the deploy bot into "Value"
+9. Type the email address associated with the Deploy Bot into "Value"
 10. Click "Add Environment Variable" to accept the changes.
 
 ### Pantheon
@@ -223,15 +223,15 @@ get to Circle's Project Settings"
 
 #### Create a Pantheon Account for your Deploy Bot
 
-For Pantheon hosted sites, we need an account for our deploy bot so that our
+For Pantheon hosted sites, we need an account for our Deploy Bot so that our
 deployments are linked to any one pantheon user.
 
 1. Log in as an administrator of your Pantheon Organization.
 2. Click your user's name in the top right corner of the dashboard
 3. Navigate down to the organization name you want to create a user for.
 4. Click the "People" tab.
-5. Click the "Add User" button
-6. Select "Team Member" for Role
+5. Click the "Add User" button.
+6. Select "Team Member" for Role.
 7. Add the same email address you created the GitHub account for previously.
 8. Click "Add User".
 9. In a new browser instance, check the email that's associated with that user.
@@ -247,30 +247,30 @@ the instructions from Pantheon to [Add Your SSH Key to Pantheon](https://pantheo
 
 1. In the same browser instance as above, follow the instructions from Pantheon
 to [Create a Machine Token](https://pantheon.io/docs/machine-tokens#create-a-machine-token)
-2. Save the machine token securely so you will have access to it. It will only
+2. Save the machine token securely, so you will have access to it. It will only
    be displayed once.
 
 #### Configure More CircleCi Environment Variables
-1. Navigate back to your CircleCI -> Project Settings -> Enviornment Variables
+1. Navigate back to your CircleCI -> Project Settings -> Environment Variables
    browser instance.
 2. Click "Add Environment Variable"
 3. Type "SITE_NAME" in the name
 4. Type the site id (or `TERMINUS SITE ID`) of your Pantheon site into "Value".
     **Note:** you can find the site id by looking at the site's dashboard in
-    pantheon. If you click the "Visit Site" button on any environment the url is
+    Pantheon. If you click the "Visit Site" button on any environment the url is
     in the format of
     `https://{{TERMINUS ENV}}-{{TERMINUS SITE}}.pantheonsite.io/`
 5. Click "Add Environment Variable" to accept the changes.
-6. Click "Add Environment Variable"
-7. Type "TERMINUS_TOKEN" in the name
-8. Copy the machine token value you saved earlier into "Value"
+6. Click "Add Environment Variable".
+7. Type "TERMINUS_TOKEN" in the name.
+8. Copy the machine token value you saved earlier into "Value".
 9. Click "Add Environment Variable" to accept the changes.
 
 ### Acquia
-* `SITE_NAME`: The acquia site id used to run acquia cloud api commands.
-* `ACQUIA_REALM`: the Cloud API Realm. Usually "prod" or "devcloud".
-* `ACQUIA_REPO`: The acquia git repo.
-#### Create a Acquia Account for your Deploy Bot
+* `SITE_NAME`: The acquia site id used to run Acquia Cloud API commands.
+* `ACQUIA_REALM`: The Cloud API Realm. Usually "prod" or "devcloud".
+* `ACQUIA_REPO`: The Acquia git repo.
+#### Create an Acquia Account for your Deploy Bot
 
 **TODO: FILL OUT THIS BIT**
 
@@ -283,23 +283,23 @@ Log out of your Acquia account or use a separate browser instance to follow
 the instructions from Acquia to [Add a public key to an Acquia profile](https://docs.acquia.com/cloud-platform/manage/ssh/enable/add-key/).
 
 #### Configure More CircleCi Environment Variables
-1. Navigate back to your CircleCI -> Project Settings -> Enviornment Variables
+1. Navigate back to your CircleCI -> Project Settings -> Environment Variables
    browser instance.
-1. Click "Add Environment Variable"
-2. Type "ACQUIA_REPO" in the name
-3. Type the Acquia Repo url into "Value".
-   **TODO:** FLESH THIS OUR MORE WITH HELP ON HOW TO GET IT
-4. Click "Add Environment Variable" to accept the changes.
-1. Click "Add Environment Variable"
-2. Type "ACQUIA_REALM" in the name
-3. Type the Acquia Realm id into "Value".
-   **TODO:** FLESH THIS OUR MORE WITH HELP ON HOW TO GET IT
-4. Click "Add Environment Variable" to accept the changes.
-5. Click "Add Environment Variable"
-6. Type "SITE_NAME" in the name
-7. Copy the acquia site id into "Value"
-   **TODO:** FLESH THIS OUR MORE WITH HELP ON HOW TO GET IT
-8. Click "Add Environment Variable" to accept the changes.
+2. Click "Add Environment Variable".
+3. Type "ACQUIA_REPO" in the name.
+4. Type the Acquia repo url into "Value".
+   **TODO:** FLESH THIS OUT MORE WITH HELP ON HOW TO GET IT
+5. Click "Add Environment Variable" to accept the changes.
+6. Click "Add Environment Variable".
+7. Type "ACQUIA_REALM" in the name.
+8. Type the Acquia Realm id into "Value".
+   **TODO:** FLESH THIS OUT MORE WITH HELP ON HOW TO GET IT
+9. Click "Add Environment Variable" to accept the changes.
+10. Click "Add Environment Variable".
+11. Type "SITE_NAME" in the name.
+12. Copy the Acquia site id into "Value".
+    **TODO:** FLESH THIS OUT MORE WITH HELP ON HOW TO GET IT
+13. Click "Add Environment Variable" to accept the changes.
 
 ## Configure CircleCI config.yml
 There are many options you have, some shared, and some hosting specific.
@@ -328,12 +328,12 @@ to
 ```
 
 The following parameters exist:
-#### php-version:
-This is a string that represents the version number for php version to use
+#### php-version
+This is a string that represents the version number for PHP version to use
 across the entire build.
 
 If you are using Pantheon as a host-variant, this can only be a major.minor
-version number such as `"8.1"` because pantheon docker containers only allow
+version number such as `"8.1"` because Pantheon Docker containers only allow
 the two digit version.
 
 On other hosting platforms, you can use a three digit version number
@@ -348,9 +348,9 @@ to find an appropriate one for you to use.
 
 #### host-variant
 This affects how the whole build behaves and what configurations are available
-to you. The current options are pantheon, acquia, general. All our workflows
-will provide you with "Artifact Build", committed the the appropriate
-repository. This allows you use git history to follow a build back to the source
+to you. The current options are "pantheon", "acquia", and "general". All our workflows
+will provide you with "Artifact Build", committed the appropriate
+repository. This allows you to use Git history to follow a build back to the source
 commit we use in development.
 
 ##### pantheon
@@ -368,7 +368,7 @@ Acquia provides you a very minimal workflow, however, it does provide
 you to use supporting deploy methods like our [cloud hooks](https://github.com/fourkitchens/acquia-cloud-hooks)
 to streamline the deployment process. For multidev capabilities, it is
 recommended to use [tugboat](https://www.tugboatqa.com/). The deploy process
-provided by this settings creates an Artifact Build using some standard git
+provided by these settings creates an Artifact Build using some standard git
 commands. These changes are committed only to the Acquia git repository and not
 to your "Source Repository", the one you create coding changes in.
 
@@ -394,21 +394,21 @@ pushed to the host.
 
 ### Other Configuration
 
-There are other configuration that cannot be affected by API calls an requires
+There are other configuration that cannot be affected by API calls and requires
 you to modify your config.yml directly if you wish to change them temporally
 or permanently.
 
 #### persisting_dirs
 There are the directories that you want to be copied in full from the build
 portion of the workflow to the deploy portion of the workflow. You will
-sometimes want to inclue other root directories that aren't included like
+sometimes want to include other root directories that aren't included like
 `node_modules`, `simplesaml`, or `private`. We exclude most top level
 directories because they are unneeded on the hosting system itself.
 
 ## Configurable Environment Variables
 
 Environment variables can be configured using the CircleCI Environment Variables
-interface, or you can set them directly in `.circleci/config.yml` Changing them
+interface, or you can set them directly in `.circleci/config.yml`. Changing them
 in the interface makes upgrading your `.circleci/config.yml` less problematic,
 however, it hides some of the toggles you may be using. Per best practices,
 make sure any secret is configured in the CircleCI UI. We also include all
@@ -416,21 +416,21 @@ mandatory environment variables in this way as well.
 
 ### Shared
 
-* `GITHUB_TOKEN`: **Manditory** A github access token so the bot user can comment back on the
+* `GITHUB_TOKEN`: **Mandatory** A GitHub access token so the bot user can comment back on the
    commit or PR, and remove unneeded multidevs.
 * `SITE_NAME`: The Pantheon or Acquia site id used to run terminus/acli
-   commands. Defaults to the Github repo name.
+   commands. Defaults to the GitHub repo name.
 * `GIT_EMAIL`: An arbitrary email that will be used as the committer when
    building the artifact. Defaults to `bender@fourkitchens.com`
 * `CANONICAL_ENV`: Environment to get canonical database and files from
    Possible Values:
-   * Acquia: dev, test prod
+   * Acquia: dev, test, prod
    * Pantheon: dev, test, live
 
    Default: "prod" on Acquia. "live" on Pantheon
-* `SANATIZE_SCRIPT`: Script used to sanatize databases. Only used when
+* `SANITIZE_SCRIPT`: Script used to sanitize databases. Only used when
    `CANONICAL_ENV` is not dev. There is no default.
-* `SYNC_CONFIG`: The ability to turn configuration sync on or off. By default
+* `SYNC_CONFIG`: The ability to turn configuration sync on or off. By default,
    Yes if Any directory in the ./config directory (inclusive) contains
    `system.site.yml`. Ex: YES if `./config/system.site.yml` or
    `./config/default/system.site.yml` or `./config/sync/system.site.yml`
@@ -438,31 +438,34 @@ mandatory environment variables in this way as well.
 
 ### Pantheon Specific
 
-* `TERMINUS_TOKEN`: **Manditory** The Pantheon machine token
+* `TERMINUS_TOKEN`: **Mandatory** The Pantheon machine token.
 * `CI_BUILD`: Build CI multidevs on every commit on Pantheon. This way you get
    the ci-* environments. This may be useful for visual regression testing or
-   workflows without PRs. Defaults to `NO`. Possible values are `YES` and `NO`
+   workflows without PRs. Defaults to `NO`. Possible values are `YES` and `NO`.
 * `MAIN_BRANCH`: Define the main branch releases are cut from. Defaults to
-   `main` if the branch it exists, `master` otherwise.
+   `main` if the branch exists, `master` otherwise.
 * `DEVELOPMENT_BRANCH`: Define the development branch where active development
-   happens on github. This branch is used most in gitflow development patterns.
-   defaults to `develop`.
+   happens on GitHub. This branch is used most in gitflow development patterns.
+   Defaults to `develop`.
 * `REBUILD_MULTIDEV_ENV_EVERY_PUSH`: Re-sync content for multidevs every time a
    push is made to Pantheon. Defaults to `NO`. Possible values are `YES` and
    `NO`.
-* `REBUILD_DEVELOPMENT_ENV_EVERY_PUSH`: Re-sync content for the Github
+* `REBUILD_DEVELOPMENT_ENV_EVERY_PUSH`: Re-sync content for the GitHub
    development multidev on Pantheon every time a push is made to
    `DEVELOPMENT_BRANCH` branch. Defaults to `NO`. Possible values are `YES` and
    `NO`.
-* `DEVELOPMENT_ENV`: Define the name of the multidev used for the Github
+* `DEVELOPMENT_ENV`: Define the name of the multidev used for the GitHub
    development branch. Must follow the multidev naming conventions for Pantheon.
    Defaults to `github-dev`.
 
 ### Acquia Specific
 
-* `ACQUIA_REPO`: **Manditory** The address of the acquia git repo. Example:
+* `ACQUIA_REPO`: **Mandatory** The address of the Acquia git repo. Example:
    `sitename@svn-21939.prod.hosting.acquia.com:sitename.git`.
-* `ACQUIA_REALM`: **Manditory** The Acquia Cloud API Realm. Usually "prod" or "devcloud". See [documentation](https://docs.acquia.com/acquia-cloud/api#realm). Defaults to `prod`.
+* `ACQUIA_REALM`: **Mandatory** The Acquia Cloud API Realm.
+   Usually "prod" or "devcloud".
+   See [documentation](https://docs.acquia.com/acquia-cloud/api#realm). 
+   Defaults to `prod`.
 
 ## Helper Environment Variables
 These environment variables are unconfigurable. They are set to help you with
@@ -472,20 +475,20 @@ parameters previously mentioned.
 * `HOST_VARIANT`: Contains the value provided by the host-variant pipeline
    parameter.
 * `DATE_TIMEZONE`: Contains the value provided by the tz pipeline parameter.
-* `DOCROOT`: Contains the value provided by th docroot pipeline parameter.
+* `DOCROOT`: Contains the value provided by the docroot pipeline parameter.
 * `TERM`: "xterm"
 
 ## Configure Composer.json
 
 There are 2 scripts that the default scripts require you to build so that it's
-reusable across th project. You must be able to run the following commands in
-your project
+reusable across the project. You must be able to run the following commands in
+your project.
 
 ```
 composer run lint
 composer run code-sniff
 ```
-See the Dependencies section for examples.
+See the [Dependencies](https://github.com/fourkitchens/pots#dependencies) section for examples.
 
 ## Configure Scripts
 
@@ -516,7 +519,7 @@ The scripts available for overload are as follows:
 - `drush-commands`: Provides the basic deployment drush commands to run update
    hooks, clear the cache, and sync configuration.
 - `drush-config-import`: Provides the commands for importing configuration. By
-   default this provides drupal 8+ ready commands like `drush cim`, but can be
+   default, this provides drupal 8+ ready commands like `drush cim`, but can be
    swapped out for something like `drush fra` if on drupal 7 or have a features
    based site configuration setup.
 - `post-drush-commands`: Some sites require changes to external systems, such

--- a/config.yml
+++ b/config.yml
@@ -99,11 +99,11 @@ env: &env
   #
   # CANONICAL_ENV: dev
 
-  # Script used to sanitize databases. Only used when CANONICAL_ENV is not dev.
+  # Script used to sanatize databases. Only used when CANONICAL_ENV is not dev.
   #
   # Default: empty
   #
-  # SANITIZE_SCRIPT: ./vendor/fourkitchens/pots/scripts/sanitize-db
+  # SANATIZE_SCRIPT: ./vendor/fourkitchens/pots/scripts/sanatize-db
 
   # Sync Configuration
   #

--- a/config.yml
+++ b/config.yml
@@ -99,11 +99,11 @@ env: &env
   #
   # CANONICAL_ENV: dev
 
-  # Script used to sanatize databases. Only used when CANONICAL_ENV is not dev.
+  # Script used to sanitize databases. Only used when CANONICAL_ENV is not dev.
   #
   # Default: empty
   #
-  # SANATIZE_SCRIPT: ./vendor/fourkitchens/pots/scripts/sanatize-db
+  # SANITIZE_SCRIPT: ./vendor/fourkitchens/pots/scripts/sanitize-db
 
   # Sync Configuration
   #

--- a/scripts/pantheon/deploy
+++ b/scripts/pantheon/deploy
@@ -41,11 +41,11 @@ then
   if [[ "$CANONICAL_ENV" != "dev" ]]
   then
     terminus -n env:clone-content "$TERMINUS_SITE.$CANONICAL_ENV" dev
-    if [[ ! -z "$SANITIZE_SCRIPT" ]]
+    if [[ ! -z "$SANATIZE_SRIPT" ]]
     then
-      echo "Sanitizing Database."
-      # If we've set a sanitization script for the database, run it.
-      $( $SANITIZE_SCRIPT )
+      echo "Sanatizing Database."
+      # If we've set a sanatization script for the database, run it.
+      $( $SANATIZE_SRIPT )
     fi
   fi
   terminus -n build:env:push "$TERMINUS_SITE.dev" --yes
@@ -57,21 +57,21 @@ else
   then
     echo "This project is set to clone content for multidevs every push."
     terminus -n build:env:create "$TERMINUS_SITE.$CANONICAL_ENV" "$TERMINUS_ENV" --clone-content $CREATE_OPTIONS
-    if [[ ! -z "$SANITIZE_SCRIPT" ]]
+    if [[ ! -z "$SANATIZE_SRIPT" ]]
     then
-      echo "Sanitizing Database."
-      # If we've set a sanitization script for the database, run it.
-      $( $SANITIZE_SCRIPT )
+      echo "Sanatizing Database."
+      # If we've set a sanatization script for the database, run it.
+      $( $SANATIZE_SRIPT )
     fi
   elif [[ "$TERMINUS_ENV" == "$DEVELOPMENT_ENV" ]] && [[ "$REBUILD_DEVELOPMENT_ENV_EVERY_PUSH" == "YES" ]]
   then
     echo "This project is set to clone content for the github development multidev every push."
     terminus -n build:env:create "$TERMINUS_SITE.$CANONICAL_ENV" "$TERMINUS_ENV" --clone-content $CREATE_OPTIONS
-    if [[ ! -z "$SANITIZE_SCRIPT" ]]
+    if [[ ! -z "$SANATIZE_SRIPT" ]]
     then
-      echo "Sanitizing Database."
-      # If we've set a sanitization script for the database, run it.
-      $( $SANITIZE_SCRIPT )
+      echo "Sanatizing Database."
+      # If we've set a sanatization script for the database, run it.
+      $( $SANATIZE_SRIPT )
     fi
   else
     terminus -n build:env:create "$TERMINUS_SITE.$CANONICAL_ENV" "$TERMINUS_ENV" $CREATE_OPTIONS

--- a/scripts/pantheon/deploy
+++ b/scripts/pantheon/deploy
@@ -41,11 +41,11 @@ then
   if [[ "$CANONICAL_ENV" != "dev" ]]
   then
     terminus -n env:clone-content "$TERMINUS_SITE.$CANONICAL_ENV" dev
-    if [[ ! -z "$SANATIZE_SRIPT" ]]
+    if [[ ! -z "$SANATIZE_SCRIPT" ]]
     then
       echo "Sanatizing Database."
       # If we've set a sanatization script for the database, run it.
-      $( $SANATIZE_SRIPT )
+      $( $SANATIZE_SCRIPT )
     fi
   fi
   terminus -n build:env:push "$TERMINUS_SITE.dev" --yes
@@ -57,21 +57,21 @@ else
   then
     echo "This project is set to clone content for multidevs every push."
     terminus -n build:env:create "$TERMINUS_SITE.$CANONICAL_ENV" "$TERMINUS_ENV" --clone-content $CREATE_OPTIONS
-    if [[ ! -z "$SANATIZE_SRIPT" ]]
+    if [[ ! -z "$SANATIZE_SCRIPT" ]]
     then
       echo "Sanatizing Database."
       # If we've set a sanatization script for the database, run it.
-      $( $SANATIZE_SRIPT )
+      $( $SANATIZE_SCRIPT )
     fi
   elif [[ "$TERMINUS_ENV" == "$DEVELOPMENT_ENV" ]] && [[ "$REBUILD_DEVELOPMENT_ENV_EVERY_PUSH" == "YES" ]]
   then
     echo "This project is set to clone content for the github development multidev every push."
     terminus -n build:env:create "$TERMINUS_SITE.$CANONICAL_ENV" "$TERMINUS_ENV" --clone-content $CREATE_OPTIONS
-    if [[ ! -z "$SANATIZE_SRIPT" ]]
+    if [[ ! -z "$SANATIZE_SCRIPT" ]]
     then
       echo "Sanatizing Database."
       # If we've set a sanatization script for the database, run it.
-      $( $SANATIZE_SRIPT )
+      $( $SANATIZE_SCRIPT )
     fi
   else
     terminus -n build:env:create "$TERMINUS_SITE.$CANONICAL_ENV" "$TERMINUS_ENV" $CREATE_OPTIONS

--- a/scripts/pantheon/deploy
+++ b/scripts/pantheon/deploy
@@ -43,8 +43,8 @@ then
     terminus -n env:clone-content "$TERMINUS_SITE.$CANONICAL_ENV" dev
     if [[ ! -z "$SANITIZE_SCRIPT" ]]
     then
-      echo "Sanatizing Database."
-      # If we've set a sanatization script for the database, run it.
+      echo "Sanitizing Database."
+      # If we've set a sanitization script for the database, run it.
       $( $SANITIZE_SCRIPT )
     fi
   fi
@@ -59,8 +59,8 @@ else
     terminus -n build:env:create "$TERMINUS_SITE.$CANONICAL_ENV" "$TERMINUS_ENV" --clone-content $CREATE_OPTIONS
     if [[ ! -z "$SANITIZE_SCRIPT" ]]
     then
-      echo "Sanatizing Database."
-      # If we've set a sanatization script for the database, run it.
+      echo "Sanitizing Database."
+      # If we've set a sanitization script for the database, run it.
       $( $SANITIZE_SCRIPT )
     fi
   elif [[ "$TERMINUS_ENV" == "$DEVELOPMENT_ENV" ]] && [[ "$REBUILD_DEVELOPMENT_ENV_EVERY_PUSH" == "YES" ]]
@@ -69,8 +69,8 @@ else
     terminus -n build:env:create "$TERMINUS_SITE.$CANONICAL_ENV" "$TERMINUS_ENV" --clone-content $CREATE_OPTIONS
     if [[ ! -z "$SANITIZE_SCRIPT" ]]
     then
-      echo "Sanatizing Database."
-      # If we've set a sanatization script for the database, run it.
+      echo "Sanitizing Database."
+      # If we've set a sanitization script for the database, run it.
       $( $SANITIZE_SCRIPT )
     fi
   else

--- a/scripts/pantheon/deploy
+++ b/scripts/pantheon/deploy
@@ -41,11 +41,11 @@ then
   if [[ "$CANONICAL_ENV" != "dev" ]]
   then
     terminus -n env:clone-content "$TERMINUS_SITE.$CANONICAL_ENV" dev
-    if [[ ! -z "$SANATIZE_SCRIPT" ]]
+    if [[ ! -z "$SANITIZE_SCRIPT" ]]
     then
       echo "Sanatizing Database."
       # If we've set a sanatization script for the database, run it.
-      $( $SANATIZE_SCRIPT )
+      $( $SANITIZE_SCRIPT )
     fi
   fi
   terminus -n build:env:push "$TERMINUS_SITE.dev" --yes
@@ -57,21 +57,21 @@ else
   then
     echo "This project is set to clone content for multidevs every push."
     terminus -n build:env:create "$TERMINUS_SITE.$CANONICAL_ENV" "$TERMINUS_ENV" --clone-content $CREATE_OPTIONS
-    if [[ ! -z "$SANATIZE_SCRIPT" ]]
+    if [[ ! -z "$SANITIZE_SCRIPT" ]]
     then
       echo "Sanatizing Database."
       # If we've set a sanatization script for the database, run it.
-      $( $SANATIZE_SCRIPT )
+      $( $SANITIZE_SCRIPT )
     fi
   elif [[ "$TERMINUS_ENV" == "$DEVELOPMENT_ENV" ]] && [[ "$REBUILD_DEVELOPMENT_ENV_EVERY_PUSH" == "YES" ]]
   then
     echo "This project is set to clone content for the github development multidev every push."
     terminus -n build:env:create "$TERMINUS_SITE.$CANONICAL_ENV" "$TERMINUS_ENV" --clone-content $CREATE_OPTIONS
-    if [[ ! -z "$SANATIZE_SCRIPT" ]]
+    if [[ ! -z "$SANITIZE_SCRIPT" ]]
     then
       echo "Sanatizing Database."
       # If we've set a sanatization script for the database, run it.
-      $( $SANATIZE_SCRIPT )
+      $( $SANITIZE_SCRIPT )
     fi
   else
     terminus -n build:env:create "$TERMINUS_SITE.$CANONICAL_ENV" "$TERMINUS_ENV" $CREATE_OPTIONS


### PR DESCRIPTION
This PR was not planned!

I started reading through the new docs so I could upgrade Sous to use pots instead of project_ci. I found one typo I intended to fix. But figured I would just make additional corrections as I found them since I was going through the entire doc anyway. Before I knew it things got carried away and nouns started getting capitalized, anchor links got fixed, number lists were reordered, punctuation got added and a global variable typo got corrected.

I tried editing this bit as well:
```
#### artifact_workspace
This setting moves where the built artifact should be. This is particularly
helpful when you want to pick and choose items from the build versus just
sending the whole artifact to your host. The `~/project` directory is the
that is committed to an "Artifact Build". By default, this value is also
`~/project`, so that everything that was built during the "build" job is then
pushed to the host.
```

But couldn't grasp this sentence enough to confidently make changes:
```
The `~/project` directory is the that is committed to an "Artifact Build".
```

That bit is located here: https://github.com/fourkitchens/pots/pull/36/files#diff-01e6d9ffed056a02cae8d8a0ec5d476a64d017bf85c0d5a94bb23ca21f33f5aaR387-R393