### PR TITLE
fix: fixing override deploy script check

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -626,7 +626,7 @@ commands:
             - run:
                 name: deploy to Pantheon
                 command: |
-                  if [ -f "./.circleci/scripts/deploy-to-live" ]; then
+                  if [ -f "./.circleci/scripts/deploy" ]; then
                     ./.circleci/scripts/deploy
                   else
                     ./vendor/fourkitchens/pots/scripts/pantheon/deploy


### PR DESCRIPTION
The script override check is checking for the wrong script path. It should check for the path that it's going to run.