### PR TITLE
fix: skip_phpstan isn't properly set if file doesn't exist

### DIFF
--- a/scripts/test/static
+++ b/scripts/test/static
@@ -25,10 +25,10 @@ if [[ "$SKIP_PHPSTAN" != "YES" ]]; then
       PHPSTAN_CONFIG_FILE="phpstan.neon.dist"
     elif [[ -f phpstan.dist.neon ]]; then
       PHPSTAN_CONFIG_FILE="phpstan.neon.dist"
+    else
+       echo "PHPStan is not configured. In the future, this will result in a default configuration being used."
+       SKIP_PHPSTAN=YES
     fi
-  else
-    echo "PHPStan is not configured. In the future, this will result in a default configuration being used."
-    SKIP_PHPSTAN=NO
   fi
 fi
 RESULTS_DIR=./test-results


### PR DESCRIPTION
## Purpose

- `$SKIP_PHPSTAN` was always set to "no" regardless of if a config file exists or not

### Functional Testing

- [ ] Update to POTS `v0.5.6` from `v0.5.5` and verify there is no `phpstan.neon` file or `PHPSTAN_CONFIG_FILE` variable isn't being set anywhere.
- [ ] Run CircleCI static tests and verify the PHPStan test is skipped
- [ ] Add a `phpstan.neon` file (see below) to the root of your project and commit. Verify the PHPStan is ran. 

Example PHPStan config file:
```
parameters:
    level: 0
    fileExtensions:
        - php
        - module
        - inc
        - install
        - theme
        - profile
    # Paths don't support wildcards :(
    excludePaths:
        - web/sites/default/files
web/sites/default/settings.local.php
    paths:
        - web/modules/custom
        - web/themes/custom
        - web/sites/default

    reportUnmatchedIgnoredErrors: false
    ignoreErrors:
        # new static() is a best practice in Drupal, so we cannot fix that.
        - "#^Unsafe usage of new static#"
```

